### PR TITLE
chore: keep golang one major release behind

### DIFF
--- a/default.json
+++ b/default.json
@@ -14,8 +14,5 @@
     "github>corazawaf/renovate-config:package-rules"
   ],
   "commitMessageSuffix": " in {{packageFile}}",
-  "dependencyDashboardAutoclose": true,
-  "constraints": {
-    "go": "1.22"
-  }
+  "dependencyDashboardAutoclose": true
 }

--- a/package-rules.json
+++ b/package-rules.json
@@ -8,6 +8,12 @@
       "automerge": true
     },
     {
+      "groupName": "golang major release",
+      "matchDatasources": ["docker", "golang-version"],
+      "matchPackageNames": ["go", "golang"],
+      "allowedVersions": "<1.23.0"
+    },
+    {
       "groupName": "go modules",
       "matchManagers": [
          "gomod"


### PR DESCRIPTION
## what

- keep golang releases one major behind
- per https://github.com/renovatebot/renovate/discussions/16922, we are using a bad syntax